### PR TITLE
Fix getCurrentArchName detection

### DIFF
--- a/lib/php/libsdk/SDK/Config.php
+++ b/lib/php/libsdk/SDK/Config.php
@@ -54,21 +54,30 @@ class Config
 	{/*{{{*/
 		if (NULL === self::$currentArchName) {
 			/* XXX this might be not true for other compilers! */
-			passthru("where cl.exe >nul", $status);
-			if ($status) {
-				throw new Exception("Couldn't find cl.exe.");
-			}
 
-			exec("cl.exe /? 2>&1", $a, $status);
+            /*
+             * this could make "cl.exe" detection simpler.
+             * we can get the arch from the the string in the end of the path,
+             * no more need to exec "cl.exe" to get detail information.
+             */
+            exec("where cl.exe 2>&1", $out, $status);
+            if ($status) {
+                throw new Exception("Couldn't find cl.exe.");
+            }
 
-			if (0 < preg_match(",x64,", $a[0])) {
-				self::setCurrentArchName("x64");
-			} elseif(0 < preg_match(",x86,", $a[0])) {
-				self::setCurrentArchName("x86");
-			} else {
-				throw new Exception("Couldn't execute cl.exe.");
-			}
-		}
+            switch (substr($out[0], -11)) {
+                case '\\x64\\cl.exe':
+                    self::setCurrentArchName("x64");
+                    break;
+                case '\\x86\\cl.exe':
+                    self::setCurrentArchName("x86");
+                    break;
+                default:
+                    throw new Exception("Couldn't determine Arch.");
+                    break;
+            }
+
+        }
 
 		return self::$currentArchName;
 	}	/*}}}*/

--- a/lib/php/libsdk/SDK/Config.php
+++ b/lib/php/libsdk/SDK/Config.php
@@ -60,14 +60,13 @@ class Config
 			}
 
 			exec("cl.exe /? 2>&1", $a, $status);
-			if ($status) {
-				throw new Exception("Couldn't execute cl.exe.");
-			}
 
-			if (preg_match(",x64,", $a[0])) {
+			if (0 < preg_match(",x64,", $a[0])) {
 				self::setCurrentArchName("x64");
-			} else {
+			} elseif(0 < preg_match(",x86,", $a[0])) {
 				self::setCurrentArchName("x86");
+			} else {
+				throw new Exception("Couldn't execute cl.exe.");
 			}
 		}
 


### PR DESCRIPTION
When executing "cl.exe /? 2>&1" under some conditions, we may both get the output and a return value not to be 0. 

For example: I install "VC++ 2017 v141 toolset (x86,x64)" and other necessary components without installing "VC++ 2015.3 v140 toolset for desktop (x86,x64)" in VS 2017, I will get an exception of "Couldn't execute cl.exe." when running "phpsdk_deps -u", because the return value is 2 somehow. But actually, the script gets the right output of the cl.exe version, which should keep it running. 
Once "VC++ 2015.3 v140 toolset for desktop (x86,x64)" is installed, everything works fine.

Havn't tested it under more conditions, only mine. 
My compiling environment is: Win10 Pro x64, VS 2017, no other software. 
Installed components: Static analysis tools, Visual Studio C++ core features, VC++ 2017 v141 toolset (x86,x64), Windows Universal CRT SDK, Windows 8.1 SDK; with or without VC++ 2015.3 v140 toolset for desktop (x86,x64) makes it different.