### PR TITLE
Ensure starter scripts keep the current directory

### DIFF
--- a/phpsdk-starter.bat
+++ b/phpsdk-starter.bat
@@ -2,6 +2,9 @@
 
 setlocal enableextensions enabledelayedexpansion
 
+rem make sure we end up where we started (for VS2017)
+set "VSCMD_START_DIR=%CD%"
+
 rem this will be eventually overridden by phpsdk_setvars, but nothing wrong to use the same name here
 set PHP_SDK_ROOT_PATH=%~dp0
 set PHP_SDK_ROOT_PATH=%PHP_SDK_ROOT_PATH:~0,-1%


### PR DESCRIPTION
If a `source` directory is found in the User profile (via
%USERPROFILE%\Source) the VS 2017 Command Prompt script will change to
this directory in its clean-up routines.

This fix uses the VSCMD_START_DIR variable which is provided as an
escape-hatch for this behavior, in `..\core\vsdevcmd_end.bat`.