### PR TITLE
Using PHP-X.Y would not work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ It is not required to hold the source in the PHP SDK directory. It could be usef
 - invoke `phpsdk-vc15-x64.bat`
 - `phpsdk_buildtree phpmaster`
 - `git clone https://github.com/php/php-src.git && cd php-src`, or fetch a zipball
-- `phpsdk_deps --update --branch master`, use PHP-X.Y for a non master branch
+- `phpsdk_deps --update --branch master`, use `phpsdk_deps --update --branch X.Y` for a non master branch
 - do the build, eg. `buildconf && configure --enable-cli && nmake`
 
 More extensive documentation can be found on the [wiki](https://wiki.php.net/internals/windows/stepbystepbuild_sdk_2 "PHP wiki page").


### PR DESCRIPTION
Typo in "Basic usage example".
Using PHP-X.Y as parameter would not work.
Working Usage is: `phpsdk_deps --update --branch X.Y`