### PR TITLE
Work around old-style constructors in PGO training case

### DIFF
--- a/pgo/cases/pgo01org/TrainingCaseHandler.php
+++ b/pgo/cases/pgo01org/TrainingCaseHandler.php
@@ -90,6 +90,13 @@ class TrainingCaseHandler extends Abstracts\TrainingCase implements Interfaces\T
 		$constants = preg_replace(",define\('DB_HOST'.+,", "define('DB_HOST', '$db_host:$db_port');", $constants);
 		file_put_contents($fl, $constants);
 
+		// work around <https://github.com/Microsoft/php-sdk-binary-tools/issues/51>
+		$fl = $htdocs . DIRECTORY_SEPARATOR . "class.php";
+		$class = file_get_contents($fl);
+		$class = preg_replace(",function Student,", "function __construct", $class);
+		$class = preg_replace(",function Faculty,", "function __construct", $class);
+		file_put_contents($fl, $class);
+
 		//$php->exec($cmd, NULL, $env);
 		/* TODO check status or switch to cli. */
 		$out = file_get_contents("http://$http_host:$http_port/init.php");


### PR DESCRIPTION
class.php of the pgo01org training case still uses PHP 4 style
constructors, which trigger deprecation notices and as such may
negatively affect the optimization.  Until this will be fixed upstream,
we're employing the workaround to modify the file during the PGO
initialization step.