### PR TITLE
Fix phpsdk_deps

### DIFF
--- a/bin/phpsdk_deps.php
+++ b/bin/phpsdk_deps.php
@@ -126,7 +126,7 @@ try {
 		usage(3);
 	}
 	/* The current CRT needs to match the config one. */
-	$active_crt = getenv("PHP_SDK_VC");
+	$active_crt = getenv("PHP_SDK_VS");
 	if (Config::getCurrentCrtName() != $active_crt && !$force) {
 		throw new Exception("Active CRT '$active_crt' differs from the branch CRT '" . Config::getCurrentCrtName() . "'.");
 	}


### PR DESCRIPTION
Rename `PHP_SDK_VC` to `PHP_SDK_VS` according to commit 76ede8f900fda61376151591e4e504ebc87c3b28.