### PR TITLE
Be more strict when looking for the desired VS

### DIFF
--- a/bin/phpsdk_setshell.bat
+++ b/bin/phpsdk_setshell.bat
@@ -87,22 +87,16 @@ if 15 gtr %PHP_SDK_VS_NUM% (
 
 	for /f "tokens=1* delims=: " %%a in ('%~dp0\vswhere -nologo -version !PHP_SDK_VS_RANGE! -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -format text') do (
 		set PHP_SDK_VC_DIR=%%b\VC
-		goto break0
 	)
-:break0
 	if not exist "!PHP_SDK_VC_DIR!" (
 		for /f "tokens=1* delims=: " %%a in ('%~dp0\vswhere -nologo -version !PHP_SDK_VS_RANGE! -products Microsoft.VisualStudio.Product.BuildTools -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -format text') do (
 			set PHP_SDK_VC_DIR=%%b\VC
-			goto break1
 		)
-:break1
 		if not exist "!PHP_SDK_VC_DIR!" (
 			rem check for a preview release
 			for /f "tokens=1* delims=: " %%a in ('%~dp0\vswhere -nologo -version !PHP_SDK_VS_RANGE! -prerelease -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -format text') do (
 				set PHP_SDK_VC_DIR=%%b\VC
-				goto break3
 			)
-:break3
 			if not exist "!PHP_SDK_VC_DIR!" (
 				echo Could not determine '%PHP_SDK_VS%' directory
 				goto out_error;

--- a/bin/phpsdk_setshell.bat
+++ b/bin/phpsdk_setshell.bat
@@ -81,21 +81,24 @@ if 15 gtr %PHP_SDK_VS_NUM% (
 	)
 	for /f "tokens=2*" %%a in ('reg query !TMPKEY! /v ProductDir') do set PHP_SDK_VC_DIR=%%b
 ) else (
-	rem the first one found seems the correct one
-	for /f "tokens=1* delims=: " %%a in ('%~dp0\vswhere -nologo -version %PHP_SDK_VS_NUM% -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -format text') do (
+	rem build the version range, e.g. "[15,16)"
+	set /a PHP_SDK_VS_RANGE=PHP_SDK_VS_NUM + 1
+	set PHP_SDK_VS_RANGE="[%PHP_SDK_VS_NUM%,!PHP_SDK_VS_RANGE%!)"
+
+	for /f "tokens=1* delims=: " %%a in ('%~dp0\vswhere -nologo -version !PHP_SDK_VS_RANGE! -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -format text') do (
 		set PHP_SDK_VC_DIR=%%b\VC
 		goto break0
 	)
 :break0
 	if not exist "!PHP_SDK_VC_DIR!" (
-		for /f "tokens=1* delims=: " %%a in ('%~dp0\vswhere -nologo -version %PHP_SDK_VS_NUM% -products Microsoft.VisualStudio.Product.BuildTools -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -format text') do (
+		for /f "tokens=1* delims=: " %%a in ('%~dp0\vswhere -nologo -version !PHP_SDK_VS_RANGE! -products Microsoft.VisualStudio.Product.BuildTools -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -format text') do (
 			set PHP_SDK_VC_DIR=%%b\VC
 			goto break1
 		)
 :break1
 		if not exist "!PHP_SDK_VC_DIR!" (
 			rem check for a preview release
-			for /f "tokens=1* delims=: " %%a in ('%~dp0\vswhere -nologo -version %PHP_SDK_VS_NUM% -prerelease -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -format text') do (
+			for /f "tokens=1* delims=: " %%a in ('%~dp0\vswhere -nologo -version !PHP_SDK_VS_RANGE! -prerelease -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath -format text') do (
 				set PHP_SDK_VC_DIR=%%b\VC
 				goto break3
 			)
@@ -109,6 +112,7 @@ if 15 gtr %PHP_SDK_VS_NUM% (
 	set VSCMD_ARG_no_logo=nologo
 )
 set TMPKEY=
+set PHP_SDK_VS_RANGE=
 
 if 15 gtr %PHP_SDK_VS_NUM% (
 	rem get sdk dir


### PR DESCRIPTION
On systems where VS 2017 and VS 2019 are available, the starter script
may choose VS 2019 if vc15 is requested.  The documentation on vswhere
isn't particularly clear regarding the -version parameter, but it
states that a version range is expected.  Therefore we change the
shell setup script accordingly.